### PR TITLE
fix (upgradeAnonymousUser): Enable display with firebaseUI for anonym…

### DIFF
--- a/projects/firebaseui-angular-library/src/lib/firebaseui-angular-library.component.ts
+++ b/projects/firebaseui-angular-library/src/lib/firebaseui-angular-library.component.ts
@@ -12,6 +12,7 @@ import {
 } from './firebaseui-angular-library.helper';
 import * as firebaseui from 'firebaseui';
 import {AngularFireAuth} from 'angularfire2/auth';
+import { User } from 'firebase/app';
 import {FirebaseuiAngularLibraryService} from './firebaseui-angular-library.service';
 // noinspection ES6UnusedImports
 import * as firebase from 'firebase/app';
@@ -63,8 +64,8 @@ export class FirebaseuiAngularLibraryComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.subscription = this.angularFireAuth.authState.subscribe(value => {
-      if (!value) {
+    this.subscription = this.angularFireAuth.authState.subscribe((value: User) => {
+      if ((value && value.isAnonymous) || !value) {
         if (this.firebaseUiConfig.providers.length !== 0) {
           this.firebaseUIPopup();
         } else {


### PR DESCRIPTION
…ous user to upgrade

The firebaseUI should be displayed even when authState is available because it is meant for anonymous to be upgraded. As discussed in https://github.com/firebase/firebaseui-web/issues/410 and https://stackoverflow.com/q/50723539/3073280.

With reference to issue #53