### PR TITLE
Fix for emulator

### DIFF
--- a/projects/firebaseui-angular-library/src/lib/firebaseui-angular-library.service.ts
+++ b/projects/firebaseui-angular-library/src/lib/firebaseui-angular-library.service.ts
@@ -24,7 +24,8 @@ export class FirebaseuiAngularLibraryService {
     if (!(<any>window).firebaseUiInstance) {
       const auth: _firebase.auth.Auth = app.auth();
       if (useEmulator) {
-        auth.useEmulator(useEmulator[0]);
+        const connectionString = useEmulator[0].startsWith('http') ? useEmulator[0] : `http://${useEmulator.join(':')}`;
+        auth.useEmulator(connectionString);
       }
       (<any>window).firebaseUiInstance = new firebaseui.auth.AuthUI(auth);
     }

--- a/projects/firebaseui-angular-library/src/lib/firebaseui-angular-library.service.ts
+++ b/projects/firebaseui-angular-library/src/lib/firebaseui-angular-library.service.ts
@@ -24,7 +24,7 @@ export class FirebaseuiAngularLibraryService {
     if (!(<any>window).firebaseUiInstance) {
       const auth: _firebase.auth.Auth = app.auth();
       if (useEmulator) {
-        auth.useEmulator(`http://${useEmulator.join(':')}`);
+        auth.useEmulator(useEmulator[0]);
       }
       (<any>window).firebaseUiInstance = new firebaseui.auth.AuthUI(auth);
     }


### PR DESCRIPTION
According to the issue the format of  USE_EMULATOR have changed. 
https://github.com/angular/angularfire/issues/2929#issuecomment-914624605

This seems to have broken FirebaseUI-Angular in that it can no longer connect to the emulator. This change fixes the issue. However it is not backwards compatible which I don't know if it is a requirement.